### PR TITLE
Fixe a megamenu e al codice HTML

### DIFF
--- a/src/components/megamenu/index.js
+++ b/src/components/megamenu/index.js
@@ -141,6 +141,9 @@ $(document).ready(function () {
           }
         }
       })
+      $el.click(function( event ) {
+        event.preventDefault()
+      })
     }
   })
 })

--- a/src/templates/layout/layout--focus.tmpl
+++ b/src/templates/layout/layout--focus.tmpl
@@ -24,7 +24,7 @@
 
     <p class="u-textCenter u-text-md-right u-text-lg-right u-margin-r-top">
       <a href="#" class="u-color-50 u-textClean u-text-h4">
-        tutti i contenuti <span class="Icon Icon-chevron-right"></a>
+        tutti i contenuti <span class="Icon Icon-chevron-right"></span></a>
     </p>
 
   </section>

--- a/src/templates/layout/layout--grid.tmpl
+++ b/src/templates/layout/layout--grid.tmpl
@@ -29,7 +29,7 @@
 
     <p class="u-textCenter u-text-md-right u-text-lg-right u-padding-r-top">
       <a href="#" class="u-color-50 u-textClean u-text-h4">
-          tutti i contenuti <span class="Icon Icon-chevron-right"></a>
+          tutti i contenuti <span class="Icon Icon-chevron-right"></span></a>
     </p>
 
   </section>

--- a/src/templates/layout/layout.tmpl
+++ b/src/templates/layout/layout.tmpl
@@ -14,7 +14,7 @@
 
     <p class="u-textCenter u-text-md-right u-text-lg-right u-padding-r-top">
       <a href="#" class="u-color-50 u-textClean u-text-h4">
-          tutti i contenuti <span class="Icon Icon-chevron-right"></a>
+          tutti i contenuti <span class="Icon Icon-chevron-right"></span></a>
     </p>
 
   </section>


### PR DESCRIPTION
Il megamenu, a volte, apre il link di primo livello invece del menu.
In alcuni modelli di layout manca un tag </span>di chiusura per l'icona chevron.