### PR TITLE
Modificato il megamenu per restare ancorato sotto la testata.

### DIFF
--- a/src/components/megamenu/index.css
+++ b/src/components/megamenu/index.css
@@ -55,8 +55,7 @@
 }
 
 .Headroom--fixed.Headroom--not-top .Megamenu-item > a,
-.Headroom--pinned.Headroom--not-top .Megamenu-item > a
- {
+.Headroom--pinned.Headroom--not-top .Megamenu-item > a {
   @extend .u-padding-top-xs;
   @extend .u-padding-bottom-xs;
 }

--- a/src/components/megamenu/index.css
+++ b/src/components/megamenu/index.css
@@ -172,6 +172,8 @@
   right: 0.5em;
 }
 
+/* postcss-bem-linter: ignore */
+
 .Headroom--fixed.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=true]::after,
 .Headroom--fixed.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=false]::after,
 .Headroom--pinned.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=true]::after,

--- a/src/components/megamenu/index.css
+++ b/src/components/megamenu/index.css
@@ -54,6 +54,13 @@
   @extend .u-padding-left-xl;
 }
 
+.Headroom--fixed.Headroom--not-top .Megamenu-item > a,
+.Headroom--pinned.Headroom--not-top .Megamenu-item > a
+ {
+  @extend .u-padding-top-xs;
+  @extend .u-padding-bottom-xs;
+}
+
 .Megamenu-item:first-child > a {
   padding-left: 0 !important;
 }
@@ -164,6 +171,13 @@
 
   bottom: 35%;
   right: 0.5em;
+}
+
+.Headroom--fixed.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=true]::after,
+.Headroom--fixed.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=false]::after,
+.Headroom--pinned.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=true]::after,
+.Headroom--pinned.Headroom--not-top .Megamenu--default .Megamenu-list > li > a[aria-expanded=false]::after {
+  bottom: 25%;
 }
 
 .Megamenu--default .Megamenu-list > li > a[aria-expanded=false]::after {

--- a/src/modules/header/header.config.json
+++ b/src/modules/header/header.config.json
@@ -9,6 +9,7 @@
     }
   },
   "isFixed": true,
+  "isMenuFixed": true,
   "variants": [
     {
       "name": "default",

--- a/src/modules/header/header.tmpl
+++ b/src/modules/header/header.tmpl
@@ -85,7 +85,7 @@
   <!-- Header-navbar -->
 
   {% if menu %}
-  <div class="Headroom-hideme u-textCenter u-hidden u-sm-hidden u-md-block u-lg-block">
+  <div class="{% if not isMenuFixed %}Headroom-hideme{% endif %} u-textCenter u-hidden u-sm-hidden u-md-block u-lg-block">
     {% if clone %}
       <nav class="Megamenu Megamenu--default js-megamenu {{ backgroundClassName }}" data-rel=".Offcanvas .Treeview"></nav>
     {% elif megamenu %}

--- a/src/modules/header/index.css
+++ b/src/modules/header/index.css
@@ -197,6 +197,11 @@
   color: var(--Header-text-color);
 }
 
+.Headroom--fixed.Headroom--not-top .Header-search button,
+.Headroom--pinned.Headroom--not-top .Header-search buttn {
+  @extend .u-padding-all-xs;
+}
+
 /* Utils block (social + languages + search form)
   ================================================ */
 

--- a/src/templates/page/page--megamenu.tmpl
+++ b/src/templates/page/page--megamenu.tmpl
@@ -1,4 +1,4 @@
 {% render '@cookiebar' %}
-{% render '@header', { menu: true, megamenu: true, clone: true }, true %}
+{% render '@header', { menu: true, megamenu: true, clone: true, isFixed: true, isMenuFixed: true }, true %}
 {% render '@offcanvas', { showOpenButton: false }, true %}
 {% render '@page--content' %}


### PR DESCRIPTION
Dopo l'eliminazione dell'hamburger sul desktop, può far comodo avere comunque il menu principale ancorato alla testata durante la navigazione.
Con questa modifica quando la pagina scrolla in alto, il megamenu resta visibile, anche se con meno padding sopra e sotto per risparmiare spazio.